### PR TITLE
add placeholder image component

### DIFF
--- a/src/Image/index.html
+++ b/src/Image/index.html
@@ -1,0 +1,28 @@
+<html>
+    <head>
+        <link rel="stylesheet" href="https://unpkg.com/tachyons@4.10.0/css/tachyons.min.css"/>
+        <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
+        <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+        <script crossorigin src="https://unpkg.com/aphrodite@2.2.1/dist/aphrodite.umd.min.js"></script>
+        <script src="../../dist/component.umd.js"></script>
+        <script src="https://sdk.v2-prod.volusion.com/element-sdk.umd.js"></script>
+    </head>
+    <body>
+        <div id="root"></div>
+    </body>
+    <script>
+        var ElementPropTypes = window.ElementSdk.ElementPropTypes;
+        
+        var name = ElementComponents.Image.name;
+        var Image = ElementComponents.Image.factory(
+              { React, ElementPropTypes },
+              aphrodite,
+              {}
+          ).component
+
+        ReactDOM.render(
+            React.createElement(Image, { src: 'http://lorempixel.com/g/1000/500/cats/' }),
+            document.getElementById('root')
+        );
+    </script>
+</html>

--- a/src/Image/index.js
+++ b/src/Image/index.js
@@ -1,0 +1,12 @@
+export const name = 'ElementImage';
+
+export const defaultConfig = {};
+
+export const factory = ({ React }) => {
+    const ElementImage = props => <img {...props} />;
+
+    return {
+        component: ElementImage,
+        config: {}
+    };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import * as Button from './Button';
 import * as Input from './Input';
 import * as LinkButton from './LinkButton';
+import * as Image from './Image';
 
-export { Button, Input, LinkButton };
+export { Button, Input, LinkButton, Image };


### PR DESCRIPTION
Adds a stripped-down `Image` component, as a placeholder for testing lazy-load functionality until the rest of the Image functionality can be ported over from [zero-Blocks](https://github.com/Volusion2Dev/zero-Blocks).

The placeholder component takes all props given to it and passes them to an `<img>` element, without modification.

Usage:
```
  <Image src='http://lorempixel.com/g/1000/500/cats/' width="1000" height="500" />
```