### PR TITLE
[V2E-1324] - group component exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-components",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-components",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Collection of reusable components across Element blocks",
   "main": "lib/index.js",
   "author": "Volusion, LLC",

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,14 @@
-import * as ButtonComponent from './ButtonComponent';
-import * as Button from './Button';
+import * as Button from './ButtonComponent';
+import * as LegacyButton from './Button';
 import * as Image from './Image';
-import * as Input from './Input';
-import * as LinkButton from './LinkButton';
 import * as Text from './Text';
 
-export { Button, Image, Input, LinkButton, ButtonComponent, Text };
+export const LegacyComponents = {
+    Button: LegacyButton
+};
+
+export const StandardComponents = {
+    Button,
+    Image,
+    Text
+};


### PR DESCRIPTION
* Updates the export structure of this package to separate the old components from the new ones. 
* Removes the Input & LinkButton components from the exports since, to my knowledge, no blocks are using them.
* Will require updates to the SDK, Renderer, and SiteDesigner to support.