### PR TITLE
[V2E-1155] Logo Component

### DIFF
--- a/src/ButtonComponent/index.html
+++ b/src/ButtonComponent/index.html
@@ -91,12 +91,12 @@
     };
 
     var buttonPrimary = React.createElement(
-      ElementComponents.ButtonComponent.block,
+      ElementComponents.StandardComponents.Button.block,
       { ...primaryBlockSettings, globalSettings }
     );
 
     var secondaryButton = React.createElement(
-      ElementComponents.ButtonComponent.block,
+      ElementComponents.StandardComponents.Button.block,
       { ...secondaryBlockSettings, globalSettings }
     );
 

--- a/src/Image/index.html
+++ b/src/Image/index.html
@@ -96,7 +96,7 @@
     };
 
     var image = React.createElement(
-      ElementComponents.Image.block,
+      ElementComponents.StandardComponents.Image.block,
       { ...blockSettings, globalSettings }
     );
 

--- a/src/Logo/Logo.spec.tsx
+++ b/src/Logo/Logo.spec.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { mount, render } from 'enzyme';
+import { block as Logo, LogoProps } from './index';
+import { defaultConfig } from './config';
+import { block as Text } from '../Text';
+import { block as Image } from '../Image';
+import { mockGlobalSettings as globalSettings } from '../__fixtures__/mockGlobalSettings';
+
+describe('Logo component', () => {
+    let props: LogoProps;
+
+    beforeEach(() => {
+        props = {
+            ...defaultConfig,
+        };
+    });
+
+    it('renders a text logo', () => {
+        const textProps = {
+            globalSettings,
+            htmlString: 'Test Store Name',
+        };
+        const TextComponent = () => <Text {...textProps}  />;
+        props.StoreName = TextComponent;
+
+        const renderedTextLogo = mount(<Logo {...props} />);
+        expect(renderedTextLogo.render()).toMatchSnapshot();
+    });
+
+    it('renders an image logo', () => {
+        const imageProps = {
+            globalSettings,
+            src: 'http://example.com/test.jpg',
+            alt: '',
+            title: '',
+            height: 10,
+            width: 10,
+            utils: {
+                isAmpRequest: false
+            }
+        };
+        const ImageComponent = () => <Image {...imageProps} />;
+        props.style = 'image';
+        props.Image = ImageComponent;
+
+        const renderedImageLogo = mount(<Logo {...props} />);
+        expect(renderedImageLogo.render()).toMatchSnapshot();
+    });
+});

--- a/src/Logo/Logo.spec.tsx
+++ b/src/Logo/Logo.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount, render } from 'enzyme';
+import { mount } from 'enzyme';
 import { block as Logo, LogoProps } from './index';
 import { defaultConfig } from './config';
 import { block as Text } from '../Text';
@@ -40,7 +40,7 @@ describe('Logo component', () => {
             }
         };
         const ImageComponent = () => <Image {...imageProps} />;
-        props.style = 'image';
+        props.style = 'Image';
         props.Image = ImageComponent;
 
         const renderedImageLogo = mount(<Logo {...props} />);

--- a/src/Logo/__snapshots__/Logo.spec.tsx.snap
+++ b/src/Logo/__snapshots__/Logo.spec.tsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Logo component renders a text logo 1`] = `
+<div>
+  Test Store Name
+</div>
+`;
+
+exports[`Logo component renders an image logo 1`] = `
+<picture>
+  <img
+    alt=""
+    height="10"
+    src="http://example.com/test.jpg"
+    style="max-width: 100%;"
+    title=""
+    width="10"
+  />
+</picture>
+`;

--- a/src/Logo/config.ts
+++ b/src/Logo/config.ts
@@ -1,0 +1,20 @@
+import { ElementPropTypes } from '@volusion/element-proptypes';
+
+export const defaultConfig = {
+  style: 'text',
+};
+
+export const configSchema = {
+  style: {
+    label: 'Style',
+    type: ElementPropTypes.oneOf(['text', 'image']),
+  },
+  Image: {
+    label: 'Image',
+    type: ElementPropTypes.component('Image'),
+  },
+  StoreName: {
+    label: 'Store Name',
+    type: ElementPropTypes.component('Text'),
+  }
+};

--- a/src/Logo/config.ts
+++ b/src/Logo/config.ts
@@ -2,13 +2,13 @@ import { ElementPropTypes } from '@volusion/element-proptypes';
 import { LogoStyle } from './index';
 
 export const defaultConfig = {
-  style: 'text' as LogoStyle,
+  style: 'Text' as LogoStyle,
 };
 
 export const configSchema = {
   style: {
     label: 'Style',
-    type: ElementPropTypes.oneOf(['text', 'image']),
+    type: ElementPropTypes.oneOf(['Text', 'Image']),
   },
   Image: {
     label: 'Image',

--- a/src/Logo/config.ts
+++ b/src/Logo/config.ts
@@ -1,7 +1,8 @@
 import { ElementPropTypes } from '@volusion/element-proptypes';
+import { LogoStyle } from './index';
 
 export const defaultConfig = {
-  style: 'text',
+  style: 'text' as LogoStyle,
 };
 
 export const configSchema = {

--- a/src/Logo/index.html
+++ b/src/Logo/index.html
@@ -63,16 +63,39 @@
 
     var ElementPropTypes = window.ElementSdk.ElementPropTypes;
 
-    var blockSettings = {
-      style: 'text',
-      storeName: 'Your Store Name',
+    const { block: Image, defaultProps: imgDefaultProps } = window.ElementComponents.StandardComponents.Image;
+    const imgProps = {
+      ...imgDefaultProps,
+      utils: { isAmpRequest: false },
+      src: 'https://res.cloudinary.com/dyx4yhvoq/image/upload/v1545428185/images/tcp-no-image.jpg',
     };
 
-    var logo = React.createElement(
+    const imageLogoSettings = {
+      style: 'image',
+      Image: () => React.createElement(Image, imgProps)
+    };
+
+    const { block: Text, defaultProps: textDefaultProps } = window.ElementComponents.StandardComponents.Text;
+    const textProps = {
+      ...textDefaultProps,
+      htmlString: 'Your Store Name'
+    }
+
+    const textLogosettings = {
+      style: 'text',
+      StoreName: () => React.createElement(Text, textProps)
+    }
+
+    var imageLogo = React.createElement(
       ElementComponents.StandardComponents.Logo.block,
-      { ...blockSettings, globalSettings }
+      { ...imageLogoSettings, globalSettings }
     );
 
-    ReactDOM.render(logo, document.getElementById("root"));
+    var textLogo = React.createElement(
+      ElementComponents.StandardComponents.Logo.block,
+      { ...textLogosettings, globalSettings }
+    );
+
+    ReactDOM.render([textLogo, imageLogo], document.getElementById("root"));
   </script>
 </html>

--- a/src/Logo/index.html
+++ b/src/Logo/index.html
@@ -71,7 +71,7 @@
     };
 
     const imageLogoSettings = {
-      style: 'image',
+      style: 'Image',
       Image: () => React.createElement(Image, imgProps)
     };
 
@@ -82,7 +82,7 @@
     }
 
     const textLogosettings = {
-      style: 'text',
+      style: 'Text',
       StoreName: () => React.createElement(Text, textProps)
     }
 

--- a/src/Logo/index.html
+++ b/src/Logo/index.html
@@ -1,0 +1,78 @@
+<html>
+  <head>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/tachyons@4.10.0/css/tachyons.min.css"
+    />
+    <script
+      crossorigin
+      src="https://unpkg.com/react@16/umd/react.development.js"
+    ></script>
+    <script
+      crossorigin
+      src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"
+    ></script>
+    <script
+      crossorigin
+      src="https://unpkg.com/aphrodite@2.2.1/dist/aphrodite.umd.min.js"
+    ></script>
+    <script src="https://sdk.v2-prod.volusion.com/element-sdk.umd.js"></script>
+    <script src="../../dist/component.umd.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+  <script>
+    var globalSettings = {
+      color: {
+        background: "#fff",
+        link: "rgba(51, 51, 51, 1)",
+        linkHover: "rgba(235, 16, 148, 1)",
+        primary: "#e53d2d",
+        salePrice: "rgba(235, 16, 148, 1)",
+        secondary: "#333",
+        text: "#000"
+      },
+      globalComponents: {
+        volComponentButton: {
+          primaryButtonStyles: {
+            size: "large",
+            rounded: "none",
+            textColor: "#fff",
+            fontWeight: "700",
+            borderColor: "rgba(247, 67, 186, 1)",
+            growOnHover: true,
+            letterSpacing: "none",
+            textTransform: "none",
+            hoverTextColor: "#fff",
+            backgroundColor: "rgba(247, 68, 186, 1)",
+            borderThickness: "none",
+            hoverBorderColor: "rgba(0, 0, 0, 1)",
+            hoverBackgroundColor: "rgba(218, 15, 148, 1)"
+          },
+        }
+      },
+      typography: {
+        baseFontSize: "16px",
+        fontFamily: '"Lato", sans-serif',
+        headingFontFamily: '"Oswald", sans-serif',
+        headingWeight: "normal",
+        lineHeight: "1.15"
+      }
+    };
+
+    var ElementPropTypes = window.ElementSdk.ElementPropTypes;
+
+    var blockSettings = {
+      style: 'text',
+      storeName: 'Your Store Name',
+    };
+
+    var logo = React.createElement(
+      ElementComponents.StandardComponents.Logo.block,
+      { ...blockSettings, globalSettings }
+    );
+
+    ReactDOM.render(logo, document.getElementById("root"));
+  </script>
+</html>

--- a/src/Logo/index.tsx
+++ b/src/Logo/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export type LogoStyle = 'text' | 'image';
+export type LogoStyle = 'Text' | 'Image';
 
 export interface LogoProps {
     style: LogoStyle;
@@ -9,7 +9,7 @@ export interface LogoProps {
 }
 
 const Logo = ({style, Image, StoreName}: LogoProps) => {
-    if (style === 'image') {
+    if (style === 'Image') {
         return <Image />;
     }
 

--- a/src/Logo/index.tsx
+++ b/src/Logo/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-type LogoStyle = 'text' | 'image';
+export type LogoStyle = 'text' | 'image';
 
-interface LogoProps {
+export interface LogoProps {
     style: LogoStyle;
     Image?: any;
     StoreName?: any;

--- a/src/Logo/index.tsx
+++ b/src/Logo/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+// import { BlockUtils, GlobalSettings } from '../../types';
+
+type LogoStyle = 'text' | 'image';
+
+interface LogoProps {
+    style: LogoStyle;
+    image?: string;
+    storeName?: string;
+}
+
+const LogoText = ({ text }: { text: string }) => (
+    <div>{text}</div>
+);
+
+const LogoImage = ({ url }: { url: string }) => (
+    <div>
+        <img src={url} />
+    </div>
+);
+
+const Logo = ({style, image, storeName}: LogoProps) => {
+    if (style === 'image') {
+        return <LogoImage url={image || ''} />;
+    }
+
+    return <LogoText text={storeName || ''} />;
+};
+
+export const block = Logo;

--- a/src/Logo/index.tsx
+++ b/src/Logo/index.tsx
@@ -1,30 +1,19 @@
 import React from 'react';
-// import { BlockUtils, GlobalSettings } from '../../types';
 
 type LogoStyle = 'text' | 'image';
 
 interface LogoProps {
     style: LogoStyle;
-    image?: string;
-    storeName?: string;
+    Image?: any;
+    StoreName?: any;
 }
 
-const LogoText = ({ text }: { text: string }) => (
-    <div>{text}</div>
-);
-
-const LogoImage = ({ url }: { url: string }) => (
-    <div>
-        <img src={url} />
-    </div>
-);
-
-const Logo = ({style, image, storeName}: LogoProps) => {
+const Logo = ({style, Image, StoreName}: LogoProps) => {
     if (style === 'image') {
-        return <LogoImage url={image || ''} />;
+        return <Image />;
     }
 
-    return <LogoText text={storeName || ''} />;
+    return <StoreName />;
 };
 
 export const block = Logo;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import * as Button from './ButtonComponent';
 import * as LegacyButton from './Button';
+import * as Logo from './Logo';
 import * as Image from './Image';
 import * as Text from './Text';
 
@@ -12,5 +13,6 @@ export const LegacyComponents = {
 export const StandardComponents = {
     Button,
     Image,
+    Logo,
     Text
 };


### PR DESCRIPTION
https://volusion-product-team.atlassian.net/browse/V2E-1155

Add Logo component.

Slight deviation from story requirements: in order to reuse components, the `Image` and `StoreName` props now accept an `Image` and a `Text` component respectively. A result of this is the `alt` and `title` props of the image logo now use the values set in the `Image` component.

<img width="365" alt="image" src="https://user-images.githubusercontent.com/583515/80656464-8019c780-8a3e-11ea-9c6e-458ccc3ec598.png">
