### PR TITLE
Image: do not fail if "utils" is not passed in

### DIFF
--- a/src/Image/index.tsx
+++ b/src/Image/index.tsx
@@ -32,7 +32,7 @@ const Img = (props: ImgProps) => (
 const Image = ({ alt, height, src, title, utils, width }: ImageProps) => {
     const imgProps = { alt, height, src, title, width };
 
-    return utils.isAmpRequest ? (
+    return utils && utils.isAmpRequest ? (
         <AmpImg layout="responsive" {...imgProps} />
     ) : (
         <Img {...imgProps} />


### PR DESCRIPTION
The element platform is not yet set up to pass the "utils" object to components. This change allows the Image component to render until the platform can be updated.

Note: The "Image" component is not currently used in production.